### PR TITLE
Remove deletion of free_text_reaction from CCDA cleanup step

### DIFF
--- a/lib/parser/ccda/cleanup.js
+++ b/lib/parser/ccda/cleanup.js
@@ -27,5 +27,4 @@ cleanup.promoteFreeTextIfNoReaction = function () {
             };
         }
     }
-    delete this.js.free_text_reaction;
 };


### PR DESCRIPTION
Persist `free_text_reaction` in final JSON for consumption during the import process.

The underlying reason is that some CCDAs will provide a reaction name, but no reaction code. When no code is present, the blue button parser will insert an `UNK` code, and remove the `free_text_reaction` value from the resulting JSON. When later processing this JSON for import, we have effectively lost information about the reaction because we don't have a SNOMED or LOINC code.

By retaining the `free_text_reaction` in the JSON whether the code is present or not,  we are able to later make more nuanced decisions about how to handle allergy JSON.