### PR TITLE
RM-48543 always generate identifiers property for Social History

### DIFF
--- a/lib/parser/ccda/sections/social_history.js
+++ b/lib/parser/ccda/sections/social_history.js
@@ -43,6 +43,9 @@ var exportSocialHistorySection = function (version) {
         }
         delete this.js.nullCodeReplacementText;
       }
+      if (!_.has(this, "js.identifiers")) {
+        this.js.identifiers = [{"identifier": null}];
+      }
     })
     // custom step to put null flavor name on value field if present
     .cleanupStep(cleanup.replaceStringFieldWithNullFlavorName("value"));

--- a/test/fixtures/parser-ccda/CCD_SocialHistory_PQ_value.xml
+++ b/test/fixtures/parser-ccda/CCD_SocialHistory_PQ_value.xml
@@ -3027,6 +3027,11 @@ https://github.com/HL7/C-CDA-Examples/blob/master/Documents/CCD/CCD%201/CCD.XML
                   <td>12</td>
                   <td>Since February, 2012</td>
                 </tr>
+                <tr ID="SexualOrientation21">
+									<td>Sexual Orientation</td>
+									<td ID="SexualOrientation21Value">Not on file</td>
+									<td/>
+								</tr>
               </tbody>
             </table>
           </text>
@@ -3054,6 +3059,25 @@ https://github.com/HL7/C-CDA-Examples/blob/master/Documents/CCD/CCD%201/CCD.XML
               </author>
             </observation>
           </entry>
+          <entry>
+						<observation classCode="OBS" moodCode="EVN">
+							<templateId extension="2022-06-01" root="2.16.840.1.113883.10.20.22.4.501"/>
+							<templateId root="2.16.840.1.113883.10.20.22.4.38"/>
+							<templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.38"/>
+							<id nullFlavor="UNK"/>
+							<code code="76690-7" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Sexual orientation"/>
+							<text>
+								<reference value="#SexualOrientation21"/>
+							</text>
+							<statusCode code="completed"/>
+							<effectiveTime nullFlavor="UNK"/>
+							<value nullFlavor="UNK" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CD">
+								<originalText>
+									<reference value="#SexualOrientation21Value"/>
+								</originalText>
+							</value>
+						</observation>
+					</entry>
         </section>
       </component>
       <!-- ************* VITAL SIGNS *************** -->

--- a/test/parser-ccda/test-parser-ccda.js
+++ b/test/parser-ccda/test-parser-ccda.js
@@ -101,6 +101,7 @@ describe('parser.js', function () {
 
     // social_history value was parsed
     expect(result.data.social_history[0].value).toBe('12');
+    expect(result.data.social_history[1].identifiers[0].identifier).toBeDefined();
 
     done();
   });


### PR DESCRIPTION
- always generate identifiers property for Social History
- for Social History section when id node is nullFlavor, return a list of `Identifiers` with `Identifier` null, so hippo can always expect property exists

RM-48543